### PR TITLE
Fix ibmcloud login

### DIFF
--- a/scripts/bx-auth.sh
+++ b/scripts/bx-auth.sh
@@ -9,8 +9,13 @@
 # shellcheck disable=SC1090
 source "$(dirname "$0")"/../scripts/resources.sh
 
-BLUEMIX_ORG="Developer Advocacy"
-BLUEMIX_SPACE="dev"
+if [ -z "${BLUEMIX_ORG}" ]; then
+  BLUEMIX_ORG="Developer Advocacy"
+fi
+
+if [ -z "${BLUEMIX_SPACE}" ]; then
+  BLUEMIX_SPACE="dev"
+fi
 
 is_pull_request "$0"
 


### PR DESCRIPTION
Allow org and space to be set in environment variables from Travis
configuration.

Signed-off-by: AnthonyAmanse <ghieamanse@gmail.com>