### PR TITLE
Fix install openwhisk script

### DIFF
--- a/scripts/install-openwhisk-docker.sh
+++ b/scripts/install-openwhisk-docker.sh
@@ -32,6 +32,9 @@ pushd incubator-openwhisk-devtools/docker-compose || exit 1
 # checkout specific commit
 git checkout 1c67cef739066f573b864b6f41f694fcae00a86b
 
+# remove this line when upstream is updated
+sed -i 's#apache/couchdb:2.1#apache/couchdb:2.3#' docker-compose.yml
+
 make quick-start
 
 # add system packages


### PR DESCRIPTION
This commit fixes the script for installing an openwhisk environment
inside Travis CI. This commit replaces the couchdb version from 2.1 to
2.3 in the docker-compose.yml file. 2.1 no longer exists in the docker
hub repo.

Signed-off-by: AnthonyAmanse <ghieamanse@gmail.com>