### PR TITLE
Update openwhisk script - devtools commit SHA

### DIFF
--- a/scripts/install-openwhisk-docker.sh
+++ b/scripts/install-openwhisk-docker.sh
@@ -30,10 +30,7 @@ cp "$(dirname "$0")"/../Makefile-openwhisk incubator-openwhisk-devtools/docker-c
 pushd incubator-openwhisk-devtools/docker-compose || exit 1
 
 # checkout specific commit
-git checkout 1c67cef739066f573b864b6f41f694fcae00a86b
-
-# remove this line when upstream is updated
-sed -i 's#apache/couchdb:2.1#apache/couchdb:2.3#' docker-compose.yml
+git checkout 1f27b3b2c5ad5dec49591ed0d4edebfeb53653d4
 
 make quick-start
 


### PR DESCRIPTION
This commit updates the install-openwhisk-docker script to checkout
the latest commit SHA on the upstream:
https://github.com/apache/incubator-openwhisk-devtools

This upstream's latest bumps the couchdb image to 2.3 which fixes the
make quick-start script due to 2.1 being deleted in docker hub repo.

Closes #14

Signed-off-by: AnthonyAmanse <ghieamanse@gmail.com>