### PR TITLE
Add support for other versions of minikube and kubectl

### DIFF
--- a/scripts/install-minikube.sh
+++ b/scripts/install-minikube.sh
@@ -3,11 +3,31 @@
 # shellcheck disable=SC1090
 source "$(dirname "$0")"/resources.sh
 
+# if KUBECTL_VERSION is not set, use latest
+if [ -z "$KUBECTL_VERSION" ]
+then
+    KUBECTL_VERSION=$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)
+    MINIKUBE_KUBERNETES=stable
+else
+    MINIKUBE_KUBERNETES="$KUBECTL_VERSION"
+fi
+
+KUBECTL_URL=https://storage.googleapis.com/kubernetes-release/release/"$KUBECTL_VERSION"/bin/linux/amd64/kubectl
+
+# if MINIKUBE_VERSION is not set, use latest
+if [ -z "$MINIKUBE_VERSION" ]
+then
+    MINIKUBE_VERSION=latest
+fi
+
+MINIKUBE_URL=https://storage.googleapis.com/minikube/releases/"$MINIKUBE_VERSION"/minikube-linux-amd64
+
 setup_minikube() {
   export CHANGE_MINIKUBE_NONE_USER=true
-  curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.9.0/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
-  curl -Lo minikube https://storage.googleapis.com/minikube/releases/v0.25.2/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
-  sudo -E minikube start --vm-driver=none --kubernetes-version=v1.9.0
+  sudo apt-get install conntrack   # required for > v1.18.0
+  curl -Lo kubectl "$KUBECTL_URL" && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+  curl -Lo minikube "$MINIKUBE_URL" && chmod +x minikube && sudo mv minikube /usr/local/bin/
+  sudo -E minikube start --vm-driver=none --kubernetes-version="$MINIKUBE_KUBERNETES"
   minikube update-context
   JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl get nodes -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; done
 }


### PR DESCRIPTION
This commit modifies the script to accept other versions of
minikube and kubectl. This commit also deploys a kubernetes version
matching the kubectl version.